### PR TITLE
Ensure the log dir creation at startup

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -28,7 +28,7 @@ export function ensureDir(dir: string) {
 
 function logsDir() {
   const dataDir = dirs("data_local");
-  
+
   if (!dataDir) {
     throw new ErgomaticError("Failed to find data directory");
   }

--- a/src/log.ts
+++ b/src/log.ts
@@ -20,14 +20,20 @@ function formatter({ loggerName, levelName, msg }: LogRecord) {
   return `[${datetime}][${loggerName}][${levelName}] ${msg}`;
 }
 
+export function ensureDir(dir: string) {
+  Deno.mkdirSync(dir, { recursive: true });
+
+  return dir;
+}
+
 function logsDir() {
   const dataDir = dirs("data_local");
-
+  
   if (!dataDir) {
     throw new ErgomaticError("Failed to find data directory");
   }
 
-  return join(dataDir, "ergomatic");
+  return ensureDir(join(dataDir, "ergomatic"));
 }
 
 interface RotatingFileHandlerOptions extends HandlerOptions {


### PR DESCRIPTION
Without this check, the application was failing with `NotFound: No such file or directory (os error 2): open '~/Library/Application Support/ergomatic/ergomatic.log'` at startup.