### PR TITLE
Add install scripts

### DIFF
--- a/.github/workflows/install_ci.yaml
+++ b/.github/workflows/install_ci.yaml
@@ -1,0 +1,29 @@
+# test that install scripts work on all operating systems
+# currently only triggered manually, could be added to the main `ci.yaml`
+# and use a filter to only run jobs if any scripts under `./scripts/install`
+# have been modified.
+name: install_ci
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: tests shell
+        shell: bash
+        run: ./scripts/install/install_test.sh
+      - name: tests powershell
+        if: matrix.os == 'windows-latest'
+        shell: powershell
+        run: ./scripts/install/install_test.ps1
+      - name: tests powershell core
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: ./scripts/install/install_test.ps1

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -1,0 +1,44 @@
+#!/usr/bin/env pwsh
+# Inspired by https://github.com/denoland/deno_install
+
+$ErrorActionPreference = 'Stop'
+
+if ($v) {
+  $Version = "v${v}"
+}
+if ($Args.Length -eq 1) {
+  $Version = $Args.Get(0)
+}
+
+$ErgomaticInstall = $env:ERGOMATIC_INSTALL
+$BinDir = if ($ErgomaticInstall) {
+  "${ErgomaticInstall}\bin"
+} else {
+  "${Home}\.ergomatic\bin"
+}
+
+$ErgomaticExe = "$BinDir\ergomatic.exe"
+$Target = 'x86_64-pc-windows-msvc'
+
+$DownloadUrl = if (!$Version) {
+  "https://github.com/nautls/ergomatic/releases/latest/download/ergomatic-${Target}.exe"
+} else {
+  "https://github.com/nautls/ergomatic/releases/download/${Version}/ergomatic-${Target}.exe"
+}
+
+if (!(Test-Path $BinDir)) {
+  New-Item $BinDir -ItemType Directory | Out-Null
+}
+
+curl.exe -Lo $ErgomaticExe $DownloadUrl
+
+$User = [System.EnvironmentVariableTarget]::User
+$Path = [System.Environment]::GetEnvironmentVariable('Path', $User)
+if (!(";${Path};".ToLower() -like "*;${BinDir};*".ToLower())) {
+  [System.Environment]::SetEnvironmentVariable('Path', "${Path};${BinDir}", $User)
+  $Env:Path += ";${BinDir}"
+}
+
+Write-Output "Ergomatic was installed successfully to ${ErgomaticExe}"
+Write-Output "Run 'ergomatic --help' to get started"
+echo "Stuck? Join the Ergo Platform discord https://discord.gg/ergo-platform-668903786361651200"

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+set -e
+
+if ! command -v unzip >/dev/null; then
+	echo "Error: unzip is required to install Ergomatic" 1>&2
+	exit 1
+fi
+
+if [ "$OS" = "Windows_NT" ]; then
+	target="x86_64-pc-windows-msvc"
+else
+	case $(uname -sm) in
+	"Darwin x86_64") target="x86_64-apple-darwin" ;;
+	"Darwin arm64") target="aarch64-apple-darwin" ;;
+	"Linux aarch64")
+		echo "Error: Official Ergomatic builds for Linux aarch64 are not available due to upstream limitations. (see: https://github.com/denoland/deno/issues/1846 )" 1>&2
+		exit 1
+		;;
+	*) target="x86_64-unknown-linux-gnu" ;;
+	esac
+fi
+
+if [ $# -eq 0 ]; then
+	ergomatic_uri="https://github.com/nautls/ergomatic/releases/latest/download/ergomatic-${target}.zip"
+else
+	ergomatic_uri="https://github.com/nautls/ergomatic/releases/download/${1}/ergomatic-${target}.zip"
+fi
+
+ergomatic_install="${ERGOMATIC_INSTALL:-$HOME/.ergomatic}"
+bin_dir="$ergomatic_install/bin"
+exe="$bin_dir/ergomatic"
+
+if [ ! -d "$bin_dir" ]; then
+	mkdir -p "$bin_dir"
+fi
+
+curl --fail --location --progress-bar --output "$exe.zip" "$ergomatic_uri"
+unzip -d "$bin_dir" -o "$exe.zip"
+chmod +x "$exe"
+rm "$exe.zip"
+
+echo "Ergomatic was installed successfully to $exe"
+if command -v ergomatic >/dev/null; then
+	echo "Run 'ergomatic --help' to get started"
+else
+	case $SHELL in
+	/bin/zsh) shell_profile=".zshrc" ;;
+	*) shell_profile=".bashrc" ;;
+	esac
+	echo "Manually add the directory to your \$HOME/$shell_profile (or similar)"
+	echo "  export ERGOMATIC_INSTALL=\"$ergomatic_install\""
+	echo "  export PATH=\"\$ERGOMATIC_INSTALL/bin:\$PATH\""
+	echo "Run '$exe --help' to get started"
+fi
+echo
+echo "Stuck? Join the Ergo Platform discord https://discord.gg/ergo-platform-668903786361651200"

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -1,11 +1,7 @@
 #!/bin/sh
+# Inspired by https://github.com/denoland/deno_install
 
 set -e
-
-if ! command -v unzip >/dev/null; then
-	echo "Error: unzip is required to install Ergomatic" 1>&2
-	exit 1
-fi
 
 if [ "$OS" = "Windows_NT" ]; then
 	target="x86_64-pc-windows-msvc"
@@ -21,10 +17,16 @@ else
 	esac
 fi
 
-if [ $# -eq 0 ]; then
-	ergomatic_uri="https://github.com/nautls/ergomatic/releases/latest/download/ergomatic-${target}.zip"
+if [ "$OS" = "Windows_NT" ]; then
+  ext=".exe"
 else
-	ergomatic_uri="https://github.com/nautls/ergomatic/releases/download/${1}/ergomatic-${target}.zip"
+  ext=""
+fi
+
+if [ $# -eq 0 ]; then
+	ergomatic_uri="https://github.com/nautls/ergomatic/releases/latest/download/ergomatic-${target}${ext}"
+else
+	ergomatic_uri="https://github.com/nautls/ergomatic/releases/download/${1}/ergomatic-${target}${ext}"
 fi
 
 ergomatic_install="${ERGOMATIC_INSTALL:-$HOME/.ergomatic}"
@@ -35,10 +37,8 @@ if [ ! -d "$bin_dir" ]; then
 	mkdir -p "$bin_dir"
 fi
 
-curl --fail --location --progress-bar --output "$exe.zip" "$ergomatic_uri"
-unzip -d "$bin_dir" -o "$exe.zip"
+curl --fail --location --progress-bar --output "$exe" "$ergomatic_uri"
 chmod +x "$exe"
-rm "$exe.zip"
 
 echo "Ergomatic was installed successfully to $exe"
 if command -v ergomatic >/dev/null; then

--- a/scripts/install/install_test.ps1
+++ b/scripts/install/install_test.ps1
@@ -20,7 +20,7 @@ if (!($ErgomaticVersion -like '*0.0.1*')) {
 # Test that we can install at a relative custom location.
 Remove-Item "bin" -Recurse -Force -ErrorAction SilentlyContinue
 $env:ERGOMATIC_INSTALL = "."
-$v = "0.0.1"; .\install.ps1
+$v = "0.0.1"; .\scripts\install\install.ps1
 $ErgomaticVersion = bin\ergomatic.exe --version
 if (!($ErgomaticVersion -like '*0.0.1*')) {
   throw $ErgomaticVersion

--- a/scripts/install/install_test.ps1
+++ b/scripts/install/install_test.ps1
@@ -1,0 +1,27 @@
+#!/usr/bin/env pwsh
+
+$ErrorActionPreference = 'Stop'
+
+# Test that we can install the latest version at the default location.
+Remove-Item "~\.ergomatic" -Recurse -Force -ErrorAction SilentlyContinue
+$env:ERGOMATIC_INSTALL = ""
+$v = $null; .\scripts\install\install.ps1
+~\.ergomatic\bin\ergomatic.exe --version
+
+# Test that we can install a specific version at a custom location.
+Remove-Item "~\ergomatic-0.0.1" -Recurse -Force -ErrorAction SilentlyContinue
+$env:ERGOMATIC_INSTALL = "$Home\ergomatic-0.0.1"
+$v = "0.0.1"; .\scripts\install\install.ps1
+$ErgomaticVersion = ~\ergomatic-0.0.1\bin\ergomatic.exe --version
+if (!($ErgomaticVersion -like '*0.0.1*')) {
+  throw $ErgomaticVersion
+}
+
+# Test that we can install at a relative custom location.
+Remove-Item "bin" -Recurse -Force -ErrorAction SilentlyContinue
+$env:ERGOMATIC_INSTALL = "."
+$v = "0.0.1"; .\install.ps1
+$ErgomaticVersion = bin\ergomatic.exe --version
+if (!($ErgomaticVersion -like '*0.0.1*')) {
+  throw $ErgomaticVersion
+}

--- a/scripts/install/install_test.sh
+++ b/scripts/install/install_test.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -e
+
+# Test that we can install the latest version at the default location.
+rm -f ~/.ergomatic/bin/ergomatic
+unset ERGOMATIC_INSTALL
+sh ./scripts/install/install.sh
+~/.ergomatic/bin/ergomatic --version
+
+# Test that we can install a specific version at a custom location.
+rm -rf ~/ergomatic-0.0.1
+export ERGOMATIC_INSTALL="$HOME/ergomatic-0.0.1"
+./scripts/install/install.sh v0.0.1
+~/ergomatic-0.0.1/bin/ergomatic --version | grep 0.0.1
+
+# Test that we can install at a relative custom location.
+export ERGOMATIC_INSTALL="."
+./scripts/install/install.sh v0.0.1
+bin/ergomatic --version | grep 0.0.1


### PR DESCRIPTION
closes #30 

Will allow `ergomatic` to be installed like so:

```sh
curl -fsSL https://raw.githubusercontent.com/nautls/ergomatic/main/scripts/install/install.sh | sh
```

Can test it out in this PR with:

```sh
curl -fsSL https://raw.githubusercontent.com/nautls/ergomatic/db1576a6adf3ddc26c42ebc092eeeb3df0de409e/scripts/install/install.sh | sh
$HOME/.ergomatic/bin/ergomatic --version
```